### PR TITLE
use master branch for cloud extension dependencies

### DIFF
--- a/.rosinstall.master
+++ b/.rosinstall.master
@@ -1,0 +1,4 @@
+- git:
+    uri: https://github.com/aws-robotics/utils-common.git
+    local-name: utils-common
+    version: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ notifications:
       - ros-contributions@amazon.com
       - travis-build@platform-notifications.robomaker.aws.a2z.com
 env:
+  global:
+    - UPSTREAM_WORKSPACE=file
+    - ROSINSTALL_FILENAME=.rosinstall.master
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
@@ -25,6 +28,5 @@ matrix:
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ros_ci
-  - git clone https://github.com/aws-robotics/utils-common.git aws-robotics/utils-common
 script:
   - .ros_ci/travis.sh


### PR DESCRIPTION
*Description of changes:*

For PR validation purposes, the Travis build should be obtaining dependencies through the latest source, not through the latest released binaries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.