### PR TITLE
Restrict aws_common dependency < 2.0.0

### DIFF
--- a/aws_ros1_common/package.xml
+++ b/aws_ros1_common/package.xml
@@ -11,7 +11,7 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>aws_common</depend>
+  <depend version_lt='2.0.0'>aws_common</depend>
   <depend>roscpp</depend>
 
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
*Description of changes:*
Set package dependency on aws_common to less than 2.0.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
