### PR TITLE
Update ParameterReader API to support ROS1/ROS2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,10 @@ env:
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,14 @@ env:
   matrix:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 matrix:
   allow_failures:
+    - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO="lunar"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 install:

--- a/aws_ros1_common/CMakeLists.txt
+++ b/aws_ros1_common/CMakeLists.txt
@@ -82,4 +82,13 @@ if(CATKIN_ENABLE_TESTING)
     ${PROJECT_NAME}
     ${catkin_LIBRARIES}
   )
+
+  add_rostest_gtest(test_parameter_reader
+          test/test_parameter_reader.test
+          test/parameter_reader_test.cpp)
+  target_link_libraries(test_parameter_reader
+    ${aws_common_LIBRARIES}
+    ${PROJECT_NAME}
+    ${catkin_LIBRARIES}
+  )
 endif()

--- a/aws_ros1_common/include/aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h
+++ b/aws_ros1_common/include/aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h
@@ -25,13 +25,24 @@ namespace Client {
 class Ros1NodeParameterReader : public ParameterReaderInterface
 {
 public:
-  AwsError ReadList(const ParameterPath & parameter_path, std::vector<std::string> & out) const override;
-  AwsError ReadDouble(const ParameterPath & parameter_path, double & out) const override;
-  AwsError ReadInt(const ParameterPath & parameter_path, int & out) const override;
-  AwsError ReadBool(const ParameterPath & parameter_path, bool & out) const override;
-  AwsError ReadStdString(const ParameterPath & parameter_path, std::string & out) const override;
-  AwsError ReadString(const ParameterPath & parameter_path, Aws::String & out) const override;
-  AwsError ReadMap(const ParameterPath & parameter_path, std::map<std::string, std::string> & out) const override;
+  using ParameterReaderInterface::ReadList;
+  using ParameterReaderInterface::ReadDouble;
+  using ParameterReaderInterface::ReadInt;
+  using ParameterReaderInterface::ReadBool;
+  using ParameterReaderInterface::ReadStdString;
+  using ParameterReaderInterface::ReadString;
+  using ParameterReaderInterface::ReadMap;
+
+  AwsError ReadList(const char * name, std::vector<std::string> & out) const override;
+  AwsError ReadDouble(const char * name, double & out) const override;
+  AwsError ReadInt(const char * name, int & out) const override;
+  AwsError ReadBool(const char * name, bool & out) const override;
+  AwsError ReadStdString(const char * name, std::string & out) const override;
+  AwsError ReadString(const char * name, Aws::String & out) const override;
+  AwsError ReadMap(const char * name, std::map<std::string, std::string> & out) const override;
+
+private:
+  std::string FormatParameterPath(const ParameterPath & param_path) const override;
 };
 
 }  // namespace Client

--- a/aws_ros1_common/include/aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h
+++ b/aws_ros1_common/include/aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h
@@ -25,13 +25,13 @@ namespace Client {
 class Ros1NodeParameterReader : public ParameterReaderInterface
 {
 public:
-  AwsError ReadList(const char * name, std::vector<std::string> & out) const override;
-  AwsError ReadDouble(const char * name, double & out) const override;
-  AwsError ReadInt(const char * name, int & out) const override;
-  AwsError ReadBool(const char * name, bool & out) const override;
-  AwsError ReadStdString(const char * name, std::string & out) const override;
-  AwsError ReadString(const char * name, Aws::String & out) const override;
-  AwsError ReadMap(const char * name, std::map<std::string, std::string> & out) const override;
+  AwsError ReadList(const ParameterPath & parameter_path, std::vector<std::string> & out) const override;
+  AwsError ReadDouble(const ParameterPath & parameter_path, double & out) const override;
+  AwsError ReadInt(const ParameterPath & parameter_path, int & out) const override;
+  AwsError ReadBool(const ParameterPath & parameter_path, bool & out) const override;
+  AwsError ReadStdString(const ParameterPath & parameter_path, std::string & out) const override;
+  AwsError ReadString(const ParameterPath & parameter_path, Aws::String & out) const override;
+  AwsError ReadMap(const ParameterPath & parameter_path, std::map<std::string, std::string> & out) const override;
 };
 
 }  // namespace Client

--- a/aws_ros1_common/package.xml
+++ b/aws_ros1_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>aws_ros1_common</name>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
   <description>Common utilities for ROS1 nodes using Amazon Web Services</description>
   <url>http://wiki.ros.org/aws_ros1_common</url>
 

--- a/aws_ros1_common/src/sdk_utils/ros1_node_parameter_reader.cpp
+++ b/aws_ros1_common/src/sdk_utils/ros1_node_parameter_reader.cpp
@@ -19,55 +19,59 @@
 namespace Aws {
 namespace Client {
 
+constexpr char kParameterNsSeparator = '/';
+constexpr char kNodeNsSeparator = '/';
+
 template <class T>
-static AwsError ReadParam(const char * name, T & out)
+static AwsError ReadParam(const ParameterPath & parameter_path, T & out)
 {
   std::string key;
-  if (ros::param::search(name, key) && ros::param::get(key, out)) {
+  std::string resolved_path = parameter_path.get_resolved_path(kNodeNsSeparator, kParameterNsSeparator);
+  if (ros::param::search(resolved_path, key) && ros::param::get(key, out)) {
     return AWS_ERR_OK;
   }
   return AWS_ERR_NOT_FOUND;
 }
 
-AwsError Ros1NodeParameterReader::ReadList(const char * name, std::vector<std::string> & out) const
+AwsError Ros1NodeParameterReader::ReadList(const ParameterPath & parameter_path, std::vector<std::string> & out) const
 {
-  return ReadParam(name, out);
+  return ReadParam(parameter_path, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadDouble(const char * name, double & out) const
+AwsError Ros1NodeParameterReader::ReadDouble(const ParameterPath & parameter_path, double & out) const
 {
-  return ReadParam(name, out);
+  return ReadParam(parameter_path, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadInt(const char * name, int & out) const
+AwsError Ros1NodeParameterReader::ReadInt(const ParameterPath & parameter_path, int & out) const
 {
-  return ReadParam(name, out);
+  return ReadParam(parameter_path, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadBool(const char * name, bool & out) const
+AwsError Ros1NodeParameterReader::ReadBool(const ParameterPath & parameter_path, bool & out) const
 {
-  return ReadParam(name, out);
+  return ReadParam(parameter_path, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadStdString(const char * name, std::string & out) const
+AwsError Ros1NodeParameterReader::ReadStdString(const ParameterPath & parameter_path, std::string & out) const
 {
-  return ReadParam(name, out);
+  return ReadParam(parameter_path, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadString(const char * name, Aws::String & out) const
+AwsError Ros1NodeParameterReader::ReadString(const ParameterPath & parameter_path, Aws::String & out) const
 {
   std::string value;
-  AwsError result = ReadStdString(name, value);
+  AwsError result = ReadStdString(parameter_path, value);
   if (result == AWS_ERR_OK) {
     out = Aws::String(value.c_str());
   }
   return result;
 }
 
-AwsError Ros1NodeParameterReader::ReadMap(const char * name,
+AwsError Ros1NodeParameterReader::ReadMap(const ParameterPath & parameter_path,
                                           std::map<std::string, std::string> & out) const
 {
-  return ReadParam(name, out);
+  return ReadParam(parameter_path, out);
 }
 
 }  // namespace Client

--- a/aws_ros1_common/src/sdk_utils/ros1_node_parameter_reader.cpp
+++ b/aws_ros1_common/src/sdk_utils/ros1_node_parameter_reader.cpp
@@ -22,57 +22,62 @@ namespace Client {
 constexpr char kParameterNsSeparator = '/';
 constexpr char kNodeNsSeparator = '/';
 
+
 template <class T>
-static AwsError ReadParam(const ParameterPath & parameter_path, T & out)
+static AwsError ReadParam(const char * name, T & out)
 {
   std::string key;
-  std::string resolved_path = parameter_path.get_resolved_path(kNodeNsSeparator, kParameterNsSeparator);
-  if (ros::param::search(resolved_path, key) && ros::param::get(key, out)) {
+  if (ros::param::search(name, key) && ros::param::get(key, out)) {
     return AWS_ERR_OK;
   }
   return AWS_ERR_NOT_FOUND;
 }
 
-AwsError Ros1NodeParameterReader::ReadList(const ParameterPath & parameter_path, std::vector<std::string> & out) const
+AwsError Ros1NodeParameterReader::ReadList(const char * name, std::vector<std::string> & out) const
 {
-  return ReadParam(parameter_path, out);
+  return ReadParam(name, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadDouble(const ParameterPath & parameter_path, double & out) const
+AwsError Ros1NodeParameterReader::ReadDouble(const char * name, double & out) const
 {
-  return ReadParam(parameter_path, out);
+  return ReadParam(name, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadInt(const ParameterPath & parameter_path, int & out) const
+AwsError Ros1NodeParameterReader::ReadInt(const char * name, int & out) const
 {
-  return ReadParam(parameter_path, out);
+  return ReadParam(name, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadBool(const ParameterPath & parameter_path, bool & out) const
+AwsError Ros1NodeParameterReader::ReadBool(const char * name, bool & out) const
 {
-  return ReadParam(parameter_path, out);
+  return ReadParam(name, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadStdString(const ParameterPath & parameter_path, std::string & out) const
+AwsError Ros1NodeParameterReader::ReadStdString(const char * name, std::string & out) const
 {
-  return ReadParam(parameter_path, out);
+  return ReadParam(name, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadString(const ParameterPath & parameter_path, Aws::String & out) const
+AwsError Ros1NodeParameterReader::ReadString(const char * name, Aws::String & out) const
 {
   std::string value;
-  AwsError result = ReadStdString(parameter_path, value);
+  AwsError result = ReadStdString(name, value);
   if (result == AWS_ERR_OK) {
     out = Aws::String(value.c_str());
   }
   return result;
 }
 
-AwsError Ros1NodeParameterReader::ReadMap(const ParameterPath & parameter_path,
+AwsError Ros1NodeParameterReader::ReadMap(const char * name,
                                           std::map<std::string, std::string> & out) const
 {
-  return ReadParam(parameter_path, out);
+  return ReadParam(name, out);
 }
 
-}  // namespace Client
-}  // namespace Aws
+std::string Ros1NodeParameterReader::FormatParameterPath(const ParameterPath & param_path) const
+{
+  return param_path.get_resolved_path(kNodeNsSeparator, kParameterNsSeparator);
+}
+
+} // namespace Client
+} // namespace Aws

--- a/aws_ros1_common/test/parameter_reader_test.cpp
+++ b/aws_ros1_common/test/parameter_reader_test.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws_common/sdk_utils/client_configuration_provider.h>
+#include <aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h>
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+#define PARAM_READER_TEST__PARAM_PREFIX "configuration_namespace9181"
+#define PARAM_READER_TEST__PARAM_KEY "someBogusParamKey"
+#define PARAM_READER_TEST__PARAM_VALUE "uk-north-2180"
+using namespace Aws::Client;
+
+class ParameterReaderTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        producer = ros::NodeHandle("~producers");
+        producer.setParam(PARAM_READER_TEST__PARAM_PREFIX "/" PARAM_READER_TEST__PARAM_KEY, PARAM_READER_TEST__PARAM_VALUE);
+    }
+    void TearDown() {
+        producer.deleteParam(PARAM_READER_TEST__PARAM_PREFIX "/" PARAM_READER_TEST__PARAM_KEY);
+        consumer.deleteParam(PARAM_READER_TEST__PARAM_PREFIX "/" PARAM_READER_TEST__PARAM_KEY);
+    }
+    ros::NodeHandle producer;
+    ros::NodeHandle consumer;
+};
+
+TEST_F(ParameterReaderTest, parameterPathResolution)
+{
+    auto parameter_reader = std::make_shared<Aws::Client::Ros1NodeParameterReader>();
+    auto param_path_flat = ParameterPath(
+        "test_parameter_reader/producers/" PARAM_READER_TEST__PARAM_PREFIX "/" PARAM_READER_TEST__PARAM_KEY
+    );
+    auto param_path_variadic = ParameterPath(
+        "test_parameter_reader", "producers", PARAM_READER_TEST__PARAM_PREFIX, PARAM_READER_TEST__PARAM_KEY
+    );
+    auto param_path_complex_no_node_ns = ParameterPath(std::vector<std::string>{},
+            std::vector<std::string>{PARAM_READER_TEST__PARAM_PREFIX, PARAM_READER_TEST__PARAM_KEY});
+    auto param_path_complex_with_node_ns = ParameterPath(
+            std::vector<std::string>{"test_parameter_reader", "producers"},
+            std::vector<std::string>{PARAM_READER_TEST__PARAM_PREFIX, PARAM_READER_TEST__PARAM_KEY});
+
+    ASSERT_EQ(param_path_flat.get_resolved_path('/', '/'), param_path_variadic.get_resolved_path('/', '/'));
+    ASSERT_EQ(param_path_flat.get_resolved_path('/', '/'), param_path_complex_with_node_ns.get_resolved_path('/', '/'));
+
+    std::string flat_result;
+    parameter_reader->ReadStdString(param_path_flat, flat_result);
+    std::string variadic_result;
+    parameter_reader->ReadStdString(param_path_variadic, variadic_result);
+    std::string complex_no_node_ns_result;
+    parameter_reader->ReadStdString(param_path_complex_no_node_ns, complex_no_node_ns_result);
+    std::string complex_with_node_ns_result;
+    parameter_reader->ReadStdString(param_path_complex_with_node_ns, complex_with_node_ns_result);
+
+    ASSERT_EQ(flat_result, variadic_result);
+    ASSERT_EQ(variadic_result, complex_with_node_ns_result);
+    ASSERT_EQ(flat_result, PARAM_READER_TEST__PARAM_VALUE);
+
+    ASSERT_EQ(std::string(), complex_no_node_ns_result);
+    consumer.setParam(PARAM_READER_TEST__PARAM_PREFIX "/" PARAM_READER_TEST__PARAM_KEY, PARAM_READER_TEST__PARAM_VALUE);
+    parameter_reader->ReadStdString(param_path_complex_no_node_ns, complex_no_node_ns_result);
+    ASSERT_EQ(complex_no_node_ns_result, complex_with_node_ns_result);
+}
+
+TEST(ParameterReader, failureTests)
+{
+    auto parameter_reader = std::make_shared<Aws::Client::Ros1NodeParameterReader>();
+    auto nonexistent_path = ParameterPath("I don't exist");
+    std::string nonexistent_path_result = PARAM_READER_TEST__PARAM_VALUE;
+    /* Querying for a nonexistent parameter should return NOT_FOUND and the out parameter remains unchanged. */
+    ASSERT_EQ(Aws::AwsError::AWS_ERR_NOT_FOUND, parameter_reader->ReadStdString(nonexistent_path, nonexistent_path_result));
+    ASSERT_EQ(nonexistent_path_result, std::string(PARAM_READER_TEST__PARAM_VALUE));
+}
+
+int main(int argc, char ** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    ros::init(argc, argv, "test_parameter_reader");
+    return RUN_ALL_TESTS();
+}

--- a/aws_ros1_common/test/test_parameter_reader.test
+++ b/aws_ros1_common/test/test_parameter_reader.test
@@ -1,0 +1,3 @@
+<launch>
+	<test test-name="test_parameter_reader" pkg="aws_ros1_common" type="test_parameter_reader"/>
+</launch>


### PR DESCRIPTION
*Description of changes:*

ROS1/ROS2 parameters are in different formats. This API change gives ParameterReader the flexibility to read ROS parameters based on differently formatted parameter names.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.