### PR TITLE
Remove legacy portions of the ParameterReader API

### DIFF
--- a/aws_ros1_common/include/aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h
+++ b/aws_ros1_common/include/aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h
@@ -25,24 +25,13 @@ namespace Client {
 class Ros1NodeParameterReader : public ParameterReaderInterface
 {
 public:
-  using ParameterReaderInterface::ReadList;
-  using ParameterReaderInterface::ReadDouble;
-  using ParameterReaderInterface::ReadInt;
-  using ParameterReaderInterface::ReadBool;
-  using ParameterReaderInterface::ReadStdString;
-  using ParameterReaderInterface::ReadString;
-  using ParameterReaderInterface::ReadMap;
-
-  AwsError ReadList(const char * name, std::vector<std::string> & out) const override;
-  AwsError ReadDouble(const char * name, double & out) const override;
-  AwsError ReadInt(const char * name, int & out) const override;
-  AwsError ReadBool(const char * name, bool & out) const override;
-  AwsError ReadStdString(const char * name, std::string & out) const override;
-  AwsError ReadString(const char * name, Aws::String & out) const override;
-  AwsError ReadMap(const char * name, std::map<std::string, std::string> & out) const override;
-
-private:
-  std::string FormatParameterPath(const ParameterPath & param_path) const override;
+  AwsError ReadParam(const ParameterPath & param_path, std::vector<std::string> & out) const override;
+  AwsError ReadParam(const ParameterPath & param_path, double & out) const override;
+  AwsError ReadParam(const ParameterPath & param_path, int & out) const override;
+  AwsError ReadParam(const ParameterPath & param_path, bool & out) const override;
+  AwsError ReadParam(const ParameterPath & param_path, std::string & out) const override;
+  AwsError ReadParam(const ParameterPath & param_path, Aws::String & out) const override;
+  AwsError ReadParam(const ParameterPath & param_path, std::map<std::string, std::string> & out) const override;
 };
 
 }  // namespace Client

--- a/aws_ros1_common/src/sdk_utils/ros1_node_parameter_reader.cpp
+++ b/aws_ros1_common/src/sdk_utils/ros1_node_parameter_reader.cpp
@@ -24,8 +24,9 @@ constexpr char kNodeNsSeparator = '/';
 
 
 template <class T>
-static AwsError ReadParam(const char * name, T & out)
+static AwsError ReadParamTemplate(const ParameterPath & param_path, T & out)
 {
+  std::string name = param_path.get_resolved_path(kNodeNsSeparator, kParameterNsSeparator);
   std::string key;
   if (ros::param::search(name, key) && ros::param::get(key, out)) {
     return AWS_ERR_OK;
@@ -33,50 +34,45 @@ static AwsError ReadParam(const char * name, T & out)
   return AWS_ERR_NOT_FOUND;
 }
 
-AwsError Ros1NodeParameterReader::ReadList(const char * name, std::vector<std::string> & out) const
+AwsError Ros1NodeParameterReader::ReadParam(const ParameterPath & param_path, std::vector<std::string> & out) const
 {
-  return ReadParam(name, out);
+  return ReadParamTemplate(param_path, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadDouble(const char * name, double & out) const
+AwsError Ros1NodeParameterReader::ReadParam(const ParameterPath & param_path, double & out) const
 {
-  return ReadParam(name, out);
+  return ReadParamTemplate(param_path, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadInt(const char * name, int & out) const
+AwsError Ros1NodeParameterReader::ReadParam(const ParameterPath & param_path, int & out) const
 {
-  return ReadParam(name, out);
+  return ReadParamTemplate(param_path, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadBool(const char * name, bool & out) const
+AwsError Ros1NodeParameterReader::ReadParam(const ParameterPath & param_path, bool & out) const
 {
-  return ReadParam(name, out);
+  return ReadParamTemplate(param_path, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadStdString(const char * name, std::string & out) const
+AwsError Ros1NodeParameterReader::ReadParam(const ParameterPath & param_path, std::string & out) const
 {
-  return ReadParam(name, out);
+  return ReadParamTemplate(param_path, out);
 }
 
-AwsError Ros1NodeParameterReader::ReadString(const char * name, Aws::String & out) const
+AwsError Ros1NodeParameterReader::ReadParam(const ParameterPath & param_path, Aws::String & out) const
 {
   std::string value;
-  AwsError result = ReadStdString(name, value);
+  AwsError result = ReadParam(param_path, value);
   if (result == AWS_ERR_OK) {
     out = Aws::String(value.c_str());
   }
   return result;
 }
 
-AwsError Ros1NodeParameterReader::ReadMap(const char * name,
+AwsError Ros1NodeParameterReader::ReadParam(const ParameterPath & param_path,
                                           std::map<std::string, std::string> & out) const
 {
-  return ReadParam(name, out);
-}
-
-std::string Ros1NodeParameterReader::FormatParameterPath(const ParameterPath & param_path) const
-{
-  return param_path.get_resolved_path(kNodeNsSeparator, kParameterNsSeparator);
+  return ReadParamTemplate(param_path, out);
 }
 
 } // namespace Client

--- a/aws_ros1_common/test/parameter_reader_test.cpp
+++ b/aws_ros1_common/test/parameter_reader_test.cpp
@@ -56,13 +56,13 @@ TEST_F(ParameterReaderTest, parameterPathResolution)
     ASSERT_EQ(param_path_flat.get_resolved_path('/', '/'), param_path_complex_with_node_ns.get_resolved_path('/', '/'));
 
     std::string flat_result;
-    parameter_reader->ReadStdString(param_path_flat, flat_result);
+    parameter_reader->ReadParam(param_path_flat, flat_result);
     std::string variadic_result;
-    parameter_reader->ReadStdString(param_path_variadic, variadic_result);
+    parameter_reader->ReadParam(param_path_variadic, variadic_result);
     std::string complex_no_node_ns_result;
-    parameter_reader->ReadStdString(param_path_complex_no_node_ns, complex_no_node_ns_result);
+    parameter_reader->ReadParam(param_path_complex_no_node_ns, complex_no_node_ns_result);
     std::string complex_with_node_ns_result;
-    parameter_reader->ReadStdString(param_path_complex_with_node_ns, complex_with_node_ns_result);
+    parameter_reader->ReadParam(param_path_complex_with_node_ns, complex_with_node_ns_result);
 
     ASSERT_EQ(flat_result, variadic_result);
     ASSERT_EQ(variadic_result, complex_with_node_ns_result);
@@ -70,7 +70,7 @@ TEST_F(ParameterReaderTest, parameterPathResolution)
 
     ASSERT_EQ(std::string(), complex_no_node_ns_result);
     consumer.setParam(PARAM_READER_TEST__PARAM_PREFIX "/" PARAM_READER_TEST__PARAM_KEY, PARAM_READER_TEST__PARAM_VALUE);
-    parameter_reader->ReadStdString(param_path_complex_no_node_ns, complex_no_node_ns_result);
+    parameter_reader->ReadParam(param_path_complex_no_node_ns, complex_no_node_ns_result);
     ASSERT_EQ(complex_no_node_ns_result, complex_with_node_ns_result);
 }
 
@@ -80,7 +80,7 @@ TEST(ParameterReader, failureTests)
     auto nonexistent_path = ParameterPath("I don't exist");
     std::string nonexistent_path_result = PARAM_READER_TEST__PARAM_VALUE;
     /* Querying for a nonexistent parameter should return NOT_FOUND and the out parameter remains unchanged. */
-    ASSERT_EQ(Aws::AwsError::AWS_ERR_NOT_FOUND, parameter_reader->ReadStdString(nonexistent_path, nonexistent_path_result));
+    ASSERT_EQ(Aws::AwsError::AWS_ERR_NOT_FOUND, parameter_reader->ReadParam(nonexistent_path, nonexistent_path_result));
     ASSERT_EQ(nonexistent_path_result, std::string(PARAM_READER_TEST__PARAM_VALUE));
 }
 


### PR DESCRIPTION
*Description of changes:*

We have decided to remove the legacy portions of the ParameterReader API. ParameterReader will now only accept ParameterPath objects for addressing parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.