### PR TITLE
Disallow use of non-ParameterPath objects in Ros1NodeParameterReader

### DIFF
--- a/aws_ros1_common/include/aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h
+++ b/aws_ros1_common/include/aws_ros1_common/sdk_utils/ros1_node_parameter_reader.h
@@ -32,6 +32,28 @@ public:
   AwsError ReadParam(const ParameterPath & param_path, std::string & out) const override;
   AwsError ReadParam(const ParameterPath & param_path, Aws::String & out) const override;
   AwsError ReadParam(const ParameterPath & param_path, std::map<std::string, std::string> & out) const override;
+
+private:
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, std::vector<std::string> & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, double & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, int & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, bool & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, Aws::String & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, std::string & out) const = delete;
+  
+  template<class InvalidType>
+  AwsError ReadParam(InvalidType arg, std::map<std::string, std::string> & out) const = delete;
 };
 
 }  // namespace Client


### PR DESCRIPTION
*Description of changes:*

We want to disallow the case of using `ReadParam("some_c_string", out)` and force the use of `ReadParam(ParameterPath("some_c_string"), out)`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
